### PR TITLE
引用周りの仕様・動作変更、及び、Forceオプションの修正

### DIFF
--- a/src/main/kotlin/io/github/kobi32768/quotebot/DiscordMessage.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/DiscordMessage.kt
@@ -1,6 +1,7 @@
 package io.github.kobi32768.quotebot
 
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.ChannelType
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
@@ -22,6 +23,13 @@ fun MessageData.isSameGuild(): Boolean {
 
 fun MessageData.isSameChannel(): Boolean {
     return this.channel == this.event.channel
+}
+
+fun MessageData.isForceQuotable(): Boolean {
+    val channel = this.channel
+    val member = this.event.member!!
+
+    return member.hasPermission(channel, Permission.MANAGE_CHANNEL) || member.hasPermission(channel, Permission.MESSAGE_MANAGE) || member.hasPermission(channel, Permission.ADMINISTRATOR)
 }
 
 fun sendRegularEmbedMessage(data: MessageData) {

--- a/src/main/kotlin/io/github/kobi32768/quotebot/DiscordMessage.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/DiscordMessage.kt
@@ -20,6 +20,10 @@ fun MessageData.isSameGuild(): Boolean {
     return this.guild == this.event.guild
 }
 
+fun MessageData.isSameChannel(): Boolean {
+    return this.channel == this.event.channel
+}
+
 fun sendRegularEmbedMessage(data: MessageData) {
     val guild = data.guild
     val channel = data.channel

--- a/src/main/kotlin/io/github/kobi32768/quotebot/DiscordRole.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/DiscordRole.kt
@@ -8,8 +8,7 @@ fun MessageData.isEveryoneViewable(): Boolean {
     val channel = this.channel
     val everyone = this.guild.roleCache.last()
 
-    return (channel.isRoleAllowed(everyone, Permission.VIEW_CHANNEL) ||
-            channel.isRoleAllowed(everyone, Permission.MESSAGE_HISTORY))
+    return channel.isRoleAllowed(everyone, Permission.VIEW_CHANNEL)
 }
 
 private fun TextChannel.isRoleAllowed(role: Role, permission: Permission): Boolean {

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Error.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Error.kt
@@ -37,6 +37,12 @@ enum class Error(    title_ja: String,     description_ja: String,
         "NSFWチャンネルからは引用できません。",
         "NSFW Channel",
         "Can't be quoted from NSFW channel."
+    ),
+    FORCE_FAILED(
+        "権限不足",
+        "Forceオプションを使用するために必要な権限がありません。",
+        "You need more permissions",
+        "You don't have the required permissions to force quoting."
     );
 
     val title       = title_ja

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
@@ -93,7 +93,11 @@ class QuoteBot : ListenerAdapter() {
 
             val quotedData = MessageData(event, quotedGuild, quotedChannel, quotedMessage)
 
-            if (quotedChannel.isNSFW) {
+            if (quotedData.isSameChannel()) {
+                sendRegularEmbedMessage(quotedData)
+                printlog("Successfully referenced", State.SUCCESS, false, quotedData)
+            }
+            else if (quotedChannel.isNSFW) {
                 printlog("Quote from NSFW channel", State.FORBIDDEN)
                 event.sendErrorMessage(Error.NSFW)
             }

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
@@ -98,13 +98,28 @@ class QuoteBot : ListenerAdapter() {
                 printlog("Successfully referenced", State.SUCCESS, false, quotedData)
             }
             else if (quotedChannel.isNSFW) {
-                printlog("Quote from NSFW channel", State.FORBIDDEN)
-                event.sendErrorMessage(Error.NSFW)
+                if (event.isForce()) {
+                    if (quotedData.isForceQuotable()) {
+                        sendRegularEmbedMessage(quotedData)
+                        printlog("Successfully referenced", State.SUCCESS, true, quotedData)
+                    } else {
+                        event.sendErrorMessage(Error.FORCE_FAILED)
+                        printlog("Need more permissions to force quoting.", State.FAILED, false, quotedData)
+                    }
+                } else {
+                    printlog("Quote from NSFW channel", State.FORBIDDEN)
+                    event.sendErrorMessage(Error.NSFW)
+                }
             }
             else if (!quotedData.isEveryoneViewable()) {
                 if (event.isForce()) {
-                    sendRegularEmbedMessage(quotedData)
-                    printlog("Successfully referenced", State.SUCCESS, true, quotedData)
+                    if (quotedData.isForceQuotable()) {
+                        sendRegularEmbedMessage(quotedData)
+                        printlog("Successfully referenced", State.SUCCESS, true, quotedData)
+                    } else {
+                        event.sendErrorMessage(Error.FORCE_FAILED)
+                        printlog("Need more permissions to force quoting.", State.FAILED, false, quotedData)
+                    }
                 } else {
                     event.sendErrorMessage(Error.FORBIDDEN)
                     printlog("@everyone doesn't have permission", State.FORBIDDEN, false, quotedData)
@@ -115,8 +130,13 @@ class QuoteBot : ListenerAdapter() {
                 printlog("Successfully referenced", State.SUCCESS, false, quotedData)
             }else {
                 if (event.isForce()) {
-                    sendRegularEmbedMessage(quotedData)
-                    printlog("Successfully referenced", State.SUCCESS, true, quotedData)
+                    if (quotedData.isForceQuotable()) {
+                        sendRegularEmbedMessage(quotedData)
+                        printlog("Successfully referenced", State.SUCCESS, true, quotedData)
+                    } else {
+                        event.sendErrorMessage(Error.FORCE_FAILED)
+                        printlog("Need more permissions to force quoting.", State.FAILED, false, quotedData)
+                    }
                 } else {
                     event.sendErrorMessage(Error.CROSS_GUILD)
                     printlog("Cross-Guild", State.FORBIDDEN, false, quotedData)


### PR DESCRIPTION
- 同じChからの引用を常時許可するように変更
- Everyoneが閲覧不可であるにも関わらず、"メッセージ履歴を読む"権限とORで確認されていたことにより、引用が可能となっていた問題を修正。これにより、"メッセージ履歴を読む"権限は確認されないようになりました。