### PR TITLE
build.gradle.ktsでCWDを参照してる

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ application {
 }
 
 group   = "io.github.kobi32768"
-version = File("./src/main/resources/version.txt").readText()
+version = file("src/main/resources/version.txt").readText()
 
 val jar by tasks.getting(Jar::class) {
     manifest {


### PR DESCRIPTION
gradleの設計的に使わないほうがベターなので変えました。
`Project.file(Any): File`はプロジェクトルートからの相対パスを受け取ります。