### PR TITLE
Refactor

### DIFF
--- a/src/main/kotlin/io/github/kobi32768/quotebot/DiscordChannel.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/DiscordChannel.kt
@@ -6,7 +6,7 @@ import net.dv8tion.jda.api.entities.GuildMessageChannel
 import net.dv8tion.jda.api.entities.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.attribute.IAgeRestrictedChannel
 
-fun Guild.getQuotableChannelById(id: String): GuildMessageChannel? {
+fun Guild.getQuotableChannelById(id: Long): GuildMessageChannel? {
     return this.getTextChannelById(id)
         ?: this.getVoiceChannelById(id)
         ?: this.getThreadChannelById(id)

--- a/src/main/kotlin/io/github/kobi32768/quotebot/DiscordLink.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/DiscordLink.kt
@@ -1,30 +1,19 @@
 package io.github.kobi32768.quotebot
 
-private fun String.extractLinks(): List<String> {
-    return Regex("""https://discord\.com/channels/\d{6,19}/\d{6,19}/\d{6,19}""")
+private val linkRegexWithValidCheck = Regex("""(?<!\\)https://discord\.com/channels/\d{6,19}/\d{6,19}/\d{6,19}""")
+private val linkRegexWithoutValidCheck = Regex("""https://discord\.com/channels/\d{6,19}/\d{6,19}/\d{6,19}""")
+
+private fun String.extractLinks(force: Boolean): List<String> {
+    return (if (force) linkRegexWithoutValidCheck else linkRegexWithValidCheck)
         .findAll(this)
         .map { it.value }
         .toList()
 }
 
-fun String.extractIDs(): List<String> {
-    return this.extractLinks()
+fun String.extractIDs(force: Boolean): List<String> {
+    return this.extractLinks(force)
         .joinToString(separator = "")
         .replace("https://discord.com/channels", "")
         .split("/")
         .drop(1)
-}
-
-fun String.areValidLinks(): List<Boolean> {
-    val list = mutableListOf<Boolean>()
-    val links = this.extractLinks()
-
-    for (i in links.indices) { // 85: length of Discord Link
-        val index = this.indexOf(links[i], i * 85)
-        when (index) {
-            0 -> list.add(true) // prev char doesn't exist
-            else -> list.add(this[index - 1] != '\\')
-        }
-    }
-    return list
 }

--- a/src/main/kotlin/io/github/kobi32768/quotebot/DiscordLink.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/DiscordLink.kt
@@ -3,17 +3,20 @@ package io.github.kobi32768.quotebot
 private val linkRegexWithValidCheck = Regex("""(?<!\\)https://discord\.com/channels/\d{6,19}/\d{6,19}/\d{6,19}""")
 private val linkRegexWithoutValidCheck = Regex("""https://discord\.com/channels/\d{6,19}/\d{6,19}/\d{6,19}""")
 
-private fun String.extractLinks(force: Boolean): List<String> {
+private fun String.extractLinks(force: Boolean): Sequence<String> {
     return (if (force) linkRegexWithoutValidCheck else linkRegexWithValidCheck)
         .findAll(this)
         .map { it.value }
-        .toList()
 }
 
-fun String.extractIDs(force: Boolean): List<String> {
-    return this.extractLinks(force)
-        .joinToString(separator = "")
-        .replace("https://discord.com/channels", "")
-        .split("/")
-        .drop(1)
-}
+fun String.extractIDs(force: Boolean): Sequence<MessageLink> = this.extractLinks(force)
+    .map { link ->
+        val (guildId, channelId, messageId) = link.removePrefix("https://discord.com/channels/").split('/')
+        MessageLink(guildId.toLong(), channelId.toLong(), messageId.toLong())
+    }
+
+data class MessageLink(
+    val guildId: Long,
+    val channelId: Long,
+    val messageId: Long,
+)

--- a/src/main/kotlin/io/github/kobi32768/quotebot/DiscordMessage.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/DiscordMessage.kt
@@ -36,7 +36,7 @@ fun MessageData.callForceQuote() {
 }
 
 fun forceQuote(data: MessageData, foundMembers: List<Member>) {
-    val member = foundMembers.getOrNull(0) // size might be 0 or 1
+    val member = foundMembers.singleOrNull()
     val channel = data.channel
 
     if (member != null) {

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
@@ -59,7 +59,7 @@ class QuoteBot : ListenerAdapter() {
                 .readText()
                 .trim()
 
-            if (commands.isContainOr("-v", "--version")) {
+            if (commands.containsAny("-v", "--version")) {
                 event.sendMessage("**Version: ** $version")
                 printlog("Displayed version ($version)", State.INFORMATION)
             }

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
@@ -92,29 +92,21 @@ class QuoteBot : ListenerAdapter() {
 
             val quotedData = MessageData(event, quotedGuild, quotedChannel, quotedMessage)
 
-            if (quotedData.isSameChannel()) {
-                sendRegularEmbedMessage(quotedData)
-                printlog("Successfully referenced", State.SUCCESS, false, quotedData)
-            } else if (quotedChannel.isNSFW()) {
-                if (event.isForce()) {
-                    quotedData.callForceQuote()
-                } else {
+            if (event.isForce()) {
+                quotedData.callForceQuote()
+            } else {
+                if (quotedData.isSameChannel()) {
+                    sendRegularEmbedMessage(quotedData)
+                    printlog("Successfully referenced", State.SUCCESS, false, quotedData)
+                } else if (quotedChannel.isNSFW()) {
                     printlog("Quote from NSFW channel", State.FORBIDDEN)
                     event.sendErrorMessage(Error.NSFW)
-                }
-            } else if (!quotedData.isEveryoneViewable()) {
-                if (event.isForce()) {
-                    quotedData.callForceQuote()
-                } else {
+                } else if (!quotedData.isEveryoneViewable()) {
                     event.sendErrorMessage(Error.FORBIDDEN)
                     printlog("@everyone doesn't have permission", State.FORBIDDEN, false, quotedData)
-                }
-            } else if (quotedData.isSameGuild()) {
-                sendRegularEmbedMessage(quotedData)
-                printlog("Successfully referenced", State.SUCCESS, false, quotedData)
-            } else {
-                if (event.isForce()) {
-                    quotedData.callForceQuote()
+                } else if (quotedData.isSameGuild()) {
+                    sendRegularEmbedMessage(quotedData)
+                    printlog("Successfully referenced", State.SUCCESS, false, quotedData)
                 } else {
                     event.sendErrorMessage(Error.CROSS_GUILD)
                     printlog("Cross-Guild", State.FORBIDDEN, false, quotedData)

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
@@ -68,8 +68,7 @@ class QuoteBot : ListenerAdapter() {
         // Quote
         if (prefix !in content) return
 
-        val ids = content.extractIDs(event.isForce())
-        for (i in ids.indices step 3) {
+        for ((guildId, channelId, messageId) in content.extractIDs(event.isForce())) {
 
             // Pre-define
             val quotedGuild: Guild
@@ -77,9 +76,9 @@ class QuoteBot : ListenerAdapter() {
             val quotedMessage: Message
 
             try {
-                quotedGuild = event.jda.getGuildById(ids[i])!!
-                quotedChannel = quotedGuild.getQuotableChannelById(ids[i + 1])!!
-                quotedMessage = quotedChannel.retrieveMessageById(ids[i + 2]).submit().get()
+                quotedGuild = event.jda.getGuildById(guildId)!!
+                quotedChannel = quotedGuild.getQuotableChannelById(channelId)!!
+                quotedMessage = quotedChannel.retrieveMessageById(messageId).submit().get()
             } catch (ex: NullPointerException) {
                 printlog("Null Pointer Exception", State.EXCEPTION)
                 event.sendErrorMessage(Error.NOT_EXIST); return

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
@@ -68,12 +68,8 @@ class QuoteBot : ListenerAdapter() {
         // Quote
         if (prefix !in content) return
 
-        val ids = content.extractIDs()
+        val ids = content.extractIDs(event.isForce())
         for (i in ids.indices step 3) {
-            if (!content.areValidLinks()[i / 3] && !event.isForce()) {
-                printlog("Invalid Link", State.INVALID)
-                continue
-            }
 
             // Pre-define
             val quotedGuild: Guild

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Main.kt
@@ -66,7 +66,7 @@ class QuoteBot : ListenerAdapter() {
         }
 
         // Quote
-        if (!content.isContain(prefix)) return
+        if (prefix !in content) return
 
         val ids = content.extractIDs()
         for (i in ids.indices step 3) {

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
@@ -18,5 +18,6 @@ fun compress64(id: String): String {
             append(chars[(id10 % 64).toInt()])
             id10 /= 64
         }
+        reverse()
     }
 }

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
@@ -7,11 +7,11 @@ fun String.isContain(substring: String): Boolean {
 }
 
 fun String.isContainOr(vararg substring: String): Boolean { // foreach もどき
-    return substring.indices.any { i: Int -> this.isContain(substring[i]) }
+    return substring.any { this.isContain(it) }
 }
 
 fun List<String>.isContainOr(vararg substring: String): Boolean {
-    return substring.indices.any { i: Int -> this.contains(substring[i]) }
+    return substring.any { this.contains(it) }
 }
 
 fun MessageReceivedEvent.isForce(): Boolean {

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
@@ -25,12 +25,10 @@ fun printlnf(text: String, vararg args: String) {
 fun compress64(id: String): String {
     val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
     var id10 = id.toLong()
-    var id64 = ""
-
-    while (id10 / 64 != 0L) {
-        id64 = chars[(id10 % 64).toInt()] + id64
-        id10 /= 64
+    return buildString {
+        while (id10 / 64 != 0L) {
+            append(chars[(id10 % 64).toInt()])
+            id10 /= 64
+        }
     }
-
-    return id64
 }

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
@@ -2,14 +2,6 @@ package io.github.kobi32768.quotebot
 
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
-fun String.isContain(substring: String): Boolean {
-    return this.indexOf(substring) >= 0
-}
-
-fun String.isContainOr(vararg substring: String): Boolean { // foreach もどき
-    return substring.any { this.isContain(it) }
-}
-
 fun List<String>.isContainOr(vararg substring: String): Boolean {
     return substring.any { this.contains(it) }
 }

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
@@ -10,10 +10,6 @@ fun MessageReceivedEvent.isForce(): Boolean {
     return this.message.contentDisplay.split(' ').containsAny("-f", "--force")
 }
 
-fun printlnf(text: String, vararg args: String) {
-    println(text.format(args))
-}
-
 fun compress64(id: String): String {
     val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
     var id10 = id.toLong()

--- a/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
@@ -2,12 +2,12 @@ package io.github.kobi32768.quotebot
 
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
-fun List<String>.isContainOr(vararg substring: String): Boolean {
+fun List<String>.containsAny(vararg substring: String): Boolean {
     return substring.any { this.contains(it) }
 }
 
 fun MessageReceivedEvent.isForce(): Boolean {
-    return this.message.contentDisplay.split(' ').isContainOr("-f", "--force")
+    return this.message.contentDisplay.split(' ').containsAny("-f", "--force")
 }
 
 fun printlnf(text: String, vararg args: String) {


### PR DESCRIPTION
kotlinっぽくない書き方(f41e9e8, 6193f15, 71f8b48, 8c40d5d, 41e4a29)と、効率の悪いの(6193f15, 0f06011, 25b7b8a)を変更しました。

e2a8adf についてはrefactoringとしてますが、破壊的変更があります。
-f権限がない場合に、-fなくても quoteできる状態でもquoteできなくなってます。これが良くなければrevertします