### PR TITLE
fix: force option detection now considers newline

### DIFF
--- a/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
+++ b/src/main/kotlin/io/github/kobi32768/quotebot/Utility.kt
@@ -16,7 +16,7 @@ fun List<String>.containsAny(vararg substring: String): Boolean {
 }
 
 fun MessageReceivedEvent.isForce(): Boolean {
-    return this.message.contentDisplay.split(' ').containsAny("-f", "--force")
+    return this.message.contentDisplay.split(' ', '\n').containsAny("-f", "--force")
 }
 
 fun compress64(id: String): String {


### PR DESCRIPTION
fix: #57 
forceオプションのsplit対象に改行を追加します。

(意図的だったかどうか覚えていませんが、これURL直後のforceじゃない場合も機能しそうですね)